### PR TITLE
Support top-level `require` with dependencies and callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,41 +26,41 @@ var through = require('through')
  */
 module.exports = function (file) {
   var data = '';
-  
+
   var stream = through(write, end);
   return stream;
-  
+
   function write(buf) { data += buf }
   function end() {
     var ast = esprima.parse(data)
       , tast
       , isAMD = false;
-    
+
     //console.log('-- ORIGINAL AST --');
     //console.log(util.inspect(ast, false, null));
     //console.log('------------------');
-    
+
     // TODO: Ensure that define is a free variable.
     // TODO: Implement support for amdWeb UMD modules.
-    
+
     estraverse.replace(ast, {
       enter: function(node) {
-        if (isDefine(node)) {
+        if (isDefine(node) || isAMDRequire(node)) {
           var parents = this.parents();
-          
+
           // Check that this module is an AMD module, as evidenced by invoking
-          // `define` at the top-level.  Any CommonJS or UMD modules are pass
-          // through unmodified.
+          // `define` or `require([], fn)` at the top-level. Any CommonJS or
+          // UMD modules are pass through unmodified.`
           if (parents.length == 2 && parents[0].type == 'Program' && parents[1].type == 'ExpressionStatement') {
             isAMD = true;
           }
         }
       },
       leave: function(node) {
-        if (isDefine(node)) {
+        if (isDefine(node) || isAMDRequire(node)) {
           if (node.arguments.length == 1 && node.arguments[0].type == 'FunctionExpression') {
             var factory = node.arguments[0];
-            
+
             if (factory.params.length == 0) {
               tast = createProgram(factory.body.body);
               this.break();
@@ -72,13 +72,13 @@ module.exports = function (file) {
           } else if (node.arguments.length == 1 && node.arguments[0].type == 'ObjectExpression') {
             // object literal
             var obj = node.arguments[0];
-            
+
             tast = createModuleExport(obj);
             this.break();
           } else if (node.arguments.length == 2 && node.arguments[0].type == 'ArrayExpression' && node.arguments[1].type == 'FunctionExpression') {
             var dependencies = node.arguments[0]
               , factory = node.arguments[1];
-            
+
             var ids = dependencies.elements.map(function(el) { return el.value });
             var vars = factory.params.map(function(el) { return el.name });
             var reqs = createRequires(ids, vars);
@@ -91,7 +91,7 @@ module.exports = function (file) {
           } else if (node.arguments.length == 3 && node.arguments[0].type == 'Literal' && node.arguments[1].type == 'ArrayExpression' && node.arguments[2].type == 'FunctionExpression') {
             var dependencies = node.arguments[1]
               , factory = node.arguments[2];
-            
+
             var ids = dependencies.elements.map(function(el) { return el.value });
             var vars = factory.params.map(function(el) { return el.name });
             var reqs = createRequires(ids, vars);
@@ -104,26 +104,26 @@ module.exports = function (file) {
           }
         } else if (isReturn(node)) {
           var parents = this.parents();
-          
-          if (parents.length == 5 && isDefine(parents[2]) && isAMD) {
+
+          if (parents.length == 5 && (isDefine(parents[2]) || isAMDRequire(parents[2])) && isAMD) {
             return createModuleExport(node.argument);
           }
         }
       }
     });
-    
+
     if (!isAMD) {
       stream.queue(data);
       stream.queue(null);
       return;
     }
-    
+
     tast = tast || ast;
-    
+
     //console.log('-- TRANSFORMED AST --');
     //console.log(util.inspect(tast, false, null));
     //console.log('---------------------');
-    
+
     var out = escodegen.generate(tast);
     stream.queue(out);
     stream.queue(null);
@@ -140,6 +140,15 @@ function isDefine(node) {
   ;
 }
 
+function isAMDRequire(node) {
+  var callee = node.callee;
+  return callee
+    && node.type == 'CallExpression'
+    && callee.type == 'Identifier'
+    && callee.name == 'require'
+  ;
+}
+
 function isReturn(node) {
   return node.type == 'ReturnStatement';
 }
@@ -151,20 +160,20 @@ function createProgram(body) {
 
 function createRequires(ids, vars) {
   var decls = [];
-  
+
   for (var i = 0, len = ids.length; i < len; ++i) {
     if (['require', 'module', 'exports'].indexOf(ids[i]) != -1) { continue; }
-    
+
     decls.push({ type: 'VariableDeclarator',
       id: { type: 'Identifier', name: vars[i] },
-      init: 
+      init:
         { type: 'CallExpression',
           callee: { type: 'Identifier', name: 'require' },
           arguments: [ { type: 'Literal', value: ids[i] } ] } });
   }
-  
+
   if (decls.length == 0) { return null; }
-  
+
   return { type: 'VariableDeclaration',
     declarations: decls,
     kind: 'var' };
@@ -172,10 +181,10 @@ function createRequires(ids, vars) {
 
 function createModuleExport(obj) {
   return { type: 'ExpressionStatement',
-    expression: 
+    expression:
      { type: 'AssignmentExpression',
        operator: '=',
-       left: 
+       left:
         { type: 'MemberExpression',
           computed: false,
           object: { type: 'Identifier', name: 'module' },

--- a/test/data/require-function-with-dependencies-and-exports.expect.js
+++ b/test/data/require-function-with-dependencies-and-exports.expect.js
@@ -1,0 +1,8 @@
+var cart = require('./cart'), inventory = require('./inventory');
+var FOO = 'bar';
+exports.color = 'blue';
+exports.size = 'large';
+exports.addToCart = function () {
+    inventory.decrement(this);
+    cart.add(this);
+};

--- a/test/data/require-function-with-dependencies-and-exports.js
+++ b/test/data/require-function-with-dependencies-and-exports.js
@@ -1,0 +1,13 @@
+//my/shirt.js now has some dependencies, a cart and inventory
+//module in the same directory as shirt.js
+require(["./cart", "./inventory"], function(cart, inventory) {
+        var FOO = "bar";
+
+        exports.color = "blue";
+        exports.size = "large";
+        exports.addToCart = function() {
+            inventory.decrement(this);
+            cart.add(this);
+        };
+    }
+);

--- a/test/data/require-function-with-dependencies.expect.js
+++ b/test/data/require-function-with-dependencies.expect.js
@@ -1,0 +1,10 @@
+var cart = require('./cart'), inventory = require('./inventory');
+var FOO = 'bar';
+module.exports = {
+    color: 'blue',
+    size: 'large',
+    addToCart: function () {
+        inventory.decrement(this);
+        cart.add(this);
+    }
+};

--- a/test/data/require-function-with-dependencies.js
+++ b/test/data/require-function-with-dependencies.js
@@ -1,0 +1,16 @@
+//my/shirt.js now has some dependencies, a cart and inventory
+//module in the same directory as shirt.js
+require(["./cart", "./inventory"], function(cart, inventory) {
+        var FOO = "bar";
+
+        //return an object to define the "my/shirt" module.
+        return {
+            color: "blue",
+            size: "large",
+            addToCart: function() {
+                inventory.decrement(this);
+                cart.add(this);
+            }
+        }
+    }
+);

--- a/test/require-function-with-dependencies-and-exports.test.js
+++ b/test/require-function-with-dependencies-and-exports.test.js
@@ -1,0 +1,29 @@
+var deamdify = require('deamdify')
+  , fs = require('fs')
+  , Stream = require('stream');
+
+
+describe('deamdify\'ing AMD module using a require function with dependencies and exports within', function() {
+
+  var stream = deamdify('test/data/require-function-with-dependencies-and-exports.js')
+
+  it('should return a stream', function() {
+    expect(stream).to.be.an.instanceOf(Stream);
+  });
+
+  it('should transform module', function(done) {
+    var output = '';
+    stream.on('data', function(buf) {
+      output += buf;
+    });
+    stream.on('end', function() {
+      var expected = fs.readFileSync('test/data/require-function-with-dependencies-and-exports.expect.js', 'utf8')
+      expect(output).to.be.equal(expected);
+      done();
+    });
+
+    var file = fs.createReadStream('test/data/require-function-with-dependencies-and-exports.js');
+    file.pipe(stream);
+  });
+
+});

--- a/test/require-function-with-dependencies.test.js
+++ b/test/require-function-with-dependencies.test.js
@@ -1,0 +1,29 @@
+var deamdify = require('deamdify')
+  , fs = require('fs')
+  , Stream = require('stream');
+
+
+describe('deamdify\'ing AMD module using a require function with dependencies', function() {
+
+  var stream = deamdify('test/data/require-function-with-dependencies.js')
+
+  it('should return a stream', function() {
+    expect(stream).to.be.an.instanceOf(Stream);
+  });
+
+  it('should transform module', function(done) {
+    var output = '';
+    stream.on('data', function(buf) {
+      output += buf;
+    });
+    stream.on('end', function() {
+      var expected = fs.readFileSync('test/data/require-function-with-dependencies.expect.js', 'utf8')
+      expect(output).to.be.equal(expected);
+      done();
+    });
+
+    var file = fs.createReadStream('test/data/require-function-with-dependencies.js');
+    file.pipe(stream);
+  });
+
+});


### PR DESCRIPTION
Hello!

I noticed that:

````js
require(['dep1', 'dep2'], function(dep1, dep2) {});
````
Didn't seem to be supported. I think it's a pretty rare thing, and a bit against the typical AMD spec, but there are places that use that in their modules (like where I work).

I'm also really sorry for the slightly messy diff. My editor's settings auto clean trailing whitespace.