### PR TITLE
Include file path on esprima.parse error

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,9 +32,15 @@ module.exports = function (file) {
   
   function write(buf) { data += buf }
   function end() {
-    var ast = esprima.parse(data)
+    var ast
       , tast
       , isAMD = false;
+    
+    try {
+      ast = esprima.parse(data)
+    } catch (error) {
+      throw 'Error deamdifying ' + file + ': ' + error;
+    }
     
     //console.log('-- ORIGINAL AST --');
     //console.log(util.inspect(ast, false, null));


### PR DESCRIPTION
My grunt browserify task would fail with:

    Fatal error: Line 2: Unexpected string

Now it fails with:

    Fatal error: Error deamdifying /path/to/my/code.js: Error: Line 2: Unexpected string