### PR TITLE
Issue #6 - Support define(moduleName, factory)

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,6 +88,10 @@ module.exports = function (file) {
               tast = createProgram(factory.body.body);
             }
             this.break();
+          } else if (node.arguments.length == 2 && node.arguments[0].type == 'Literal' && node.arguments[1].type == 'FunctionExpression') {
+            var factory = node.arguments[1];
+            tast = createProgram(factory.body.body);
+            this.break();
           } else if (node.arguments.length == 3 && node.arguments[0].type == 'Literal' && node.arguments[1].type == 'ArrayExpression' && node.arguments[2].type == 'FunctionExpression') {
             var dependencies = node.arguments[1]
               , factory = node.arguments[2];

--- a/test/data/define-module-name-factory-return.expect.js
+++ b/test/data/define-module-name-factory-return.expect.js
@@ -1,0 +1,2 @@
+var foo = require('foo');
+module.exports = { bar: {} };

--- a/test/data/define-module-name-factory-return.js
+++ b/test/data/define-module-name-factory-return.js
@@ -1,0 +1,6 @@
+define('amd-module', function (require) {
+  var foo = require('foo');
+  return {
+    bar: {}
+  };
+});

--- a/test/data/define-module-name-factory.expect.js
+++ b/test/data/define-module-name-factory.expect.js
@@ -1,0 +1,2 @@
+var foo = require('foo');
+exports.bar = {};

--- a/test/data/define-module-name-factory.js
+++ b/test/data/define-module-name-factory.js
@@ -1,0 +1,4 @@
+define('amd-module', function (require, exports, module) {
+  var foo = require('foo');
+  exports.bar = {};
+});

--- a/test/define-module-name-factory-return.test.js
+++ b/test/define-module-name-factory-return.test.js
@@ -1,0 +1,29 @@
+var deamdify = require('deamdify')
+  , fs = require('fs')
+  , Stream = require('stream');
+
+
+describe('deamdify\'ing AMD module defining a module using only a name and a factory function that returns definition', function() {
+  
+  var stream = deamdify('test/data/define-module-name-factory-return.js')
+  
+  it('should return a stream', function() {
+    expect(stream).to.be.an.instanceOf(Stream);
+  });
+  
+  it('should transform module', function(done) {
+    var output = '';
+    stream.on('data', function(buf) {
+      output += buf;
+    });
+    stream.on('end', function() {
+      var expected = fs.readFileSync('test/data/define-module-name-factory-return.expect.js', 'utf8')
+      expect(output).to.be.equal(expected);
+      done();
+    });
+    
+    var file = fs.createReadStream('test/data/define-module-name-factory-return.js');
+    file.pipe(stream);
+  });
+  
+});

--- a/test/define-module-name-factory.test.js
+++ b/test/define-module-name-factory.test.js
@@ -1,0 +1,29 @@
+var deamdify = require('deamdify')
+  , fs = require('fs')
+  , Stream = require('stream');
+
+
+describe('deamdify\'ing AMD module defining a module using only a name and a factory function', function() {
+  
+  var stream = deamdify('test/data/define-module-name-factory.js')
+  
+  it('should return a stream', function() {
+    expect(stream).to.be.an.instanceOf(Stream);
+  });
+  
+  it('should transform module', function(done) {
+    var output = '';
+    stream.on('data', function(buf) {
+      output += buf;
+    });
+    stream.on('end', function() {
+      var expected = fs.readFileSync('test/data/define-module-name-factory.expect.js', 'utf8')
+      expect(output).to.be.equal(expected);
+      done();
+    });
+    
+    var file = fs.createReadStream('test/data/define-module-name-factory.js');
+    file.pipe(stream);
+  });
+  
+});


### PR DESCRIPTION
According to the [AMD spec](https://github.com/amdjs/amdjs-api/wiki/AMD):
* "The dependencies argument is optional. If omitted, it should default to ["require", "exports", "module"]."
* ` define(id?, dependencies?, factory);`

This Pull Request will result in `define(moduleName, factoryFunc)` being correctly deamdified. Test cases have been added and all tests are passing.

Please review and let me know if you see any issues.

Thanks,
Patrick