### PR TITLE
Allow rewriting path of modules in define.

### DIFF
--- a/test/data/module-with-a-name-rewritten.expect.js
+++ b/test/data/module-with-a-name-rewritten.expect.js
@@ -1,0 +1,4 @@
+var cart = require('mymodule/src/cart'), inventory = require('mymodule/src/inventory');
+function Foo() {
+}
+module.exports = Foo;

--- a/test/module-with-a-name-rewritten.test.js
+++ b/test/module-with-a-name-rewritten.test.js
@@ -1,0 +1,29 @@
+var deamdify = require('deamdify')
+  , fs = require('fs')
+  , Stream = require('stream');
+
+
+describe('deamdify\'ing AMD module that has a name', function() {
+
+  var stream = deamdify('test/data/module-with-a-name.js', { "rewrites": { "my": "mymodule/src" }})
+
+  it('should return a stream', function() {
+    expect(stream).to.be.an.instanceOf(Stream);
+  });
+
+  it('should transform module', function(done) {
+    var output = '';
+    stream.on('data', function(buf) {
+      output += buf;
+    });
+    stream.on('end', function() {
+      var expected = fs.readFileSync('test/data/module-with-a-name-rewritten.expect.js', 'utf8')
+      expect(output).to.be.equal(expected);
+      done();
+    });
+
+    var file = fs.createReadStream('test/data/module-with-a-name.js');
+    file.pipe(stream);
+  });
+
+});


### PR DESCRIPTION
This PR adds the ability to rewrite the path of a module. The rewrites are passed as options to the deamdify transform.

Example:
```
// package.json
{
  ...
  "browserify": {
    "transform": [
      ["deamdify", {
        "rewrites": {
          "uri": "URIjs/src"
        }
      }]
    ]
  }
}
```

This will transform:

```
define(["uri/URI"], function(URI) {
  ...
})
```
to
```
var URI = require("URIjs/src/URI");
...
```

This relates to #14 .