### PR TITLE
Add browserify peerDependency and test all major versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,12 @@ package as it builds a bundle.
 
 ## Tests
 
-    $ npm install
-    $ npm test
+```sh
+$ npm install
+# fast run
+$ npm run test-main
+# test all browserify major versions
+$ npm test
 
 ## Credits
 

--- a/package.json
+++ b/package.json
@@ -34,11 +34,16 @@
     "escodegen": "^1.6.1"
   },
   "devDependencies": {
+    "chai": "^2.2.0",
     "mocha": "^2.2.4",
-    "chai": "^2.2.0"
+    "test-peer-range": "^1.0.1"
+  },
+  "peerDependencies": {
+    "browserify": ">= 2"
   },
   "scripts": {
-    "test": "mocha --reporter spec --require test/bootstrap/node test/*.test.js"
+    "test": "test-peer-range browserify",
+    "test-main": "mocha --reporter spec --require test/bootstrap/node test/*.test.js"
   },
   "engines": {
     "node": ">= 0.6.0"


### PR DESCRIPTION
test-peer-range iterates across major versions and helps defend against regressions against old versions or breaking changes to browserify that affect deamdify