### PR TITLE
Pluginsupport

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ var through = require('through')
   , escodegen = require('escodegen')
   , path = require('path')
   , util = require('util')
-  , support = require('./support');
+  , support = require('./support')
+  , createPluginDependencyExpressionBuilder = require('./pluginSupport');
 
 
 /**
@@ -340,6 +341,7 @@ function defaultRequireDependencyExpressionBuilder(dependencyId) {
 function buildDependencyExpressions(dependencyIdList) {
   var dependencyExpressionBuilders = [
     commonJsSpecialDependencyExpressionBuilder,
+    createPluginDependencyExpressionBuilder(),
     defaultRequireDependencyExpressionBuilder
   ];
 

--- a/index.js
+++ b/index.js
@@ -255,14 +255,18 @@ function generateCommonJsModuleForFactory(dependenciesIds, factory) {
     program = factory.body.body;
   } else {
 
-    var importExpressions = [];
+    var preImports = [],
+        importExpressions = [];
 
     //build imports
     var imports;
     if(dependenciesIds.length > 0) {
-        buildDependencyExpressions(dependenciesIds).forEach(function(expressions){
-            importExpressions.push(expressions.importExpression);
-        });
+      buildDependencyExpressions(dependenciesIds).forEach(function(expressions){
+        if(expressions.preImportExpressions) {
+          [].push.apply(preImports, expressions.preImportExpressions);
+        }
+        importExpressions.push(expressions.importExpression);
+      });
     }
 
     var callFactoryWithImports = {
@@ -304,7 +308,11 @@ function generateCommonJsModuleForFactory(dependenciesIds, factory) {
 
 
     //program
-    program = [body];
+    program = [];
+    if (preImports.length > 0) {
+      [].push.apply(program, preImports);
+    }
+    program.push(body);
   }
   return { type: 'Program',
            body: program };

--- a/pluginSupport.js
+++ b/pluginSupport.js
@@ -1,0 +1,10 @@
+function createPluginDependencyExpressionBuilder() {
+
+  return function pluginDependencyExpressionBuilder() {
+
+  };
+}
+
+
+
+module.exports = createPluginDependencyExpressionBuilder;

--- a/pluginSupport.js
+++ b/pluginSupport.js
@@ -1,10 +1,184 @@
-function createPluginDependencyExpressionBuilder() {
+function isPlugin(dependencyId) {
+  return dependencyId.indexOf('!') !== -1;
+}
 
-  return function pluginDependencyExpressionBuilder() {
+function generateVariableNameForModule(dependencyId) {
+  return "m_" + dependencyId.replace(/[\/-]/g,"_").replace(/\./g,"");
+}
 
+
+/* Used within VariableDeclaration
+ * example: var $moduleName = require($dependencyId),
+ *              $paramName;
+ */
+function buildModuleAndParamaterDeclaration(moduleName, dependencyId, paramName) {
+return {
+      "type": "VariableDeclaration",
+      "declarations": [{
+          "type": "VariableDeclarator",
+          "id": {
+              "type": "Identifier",
+              "name": moduleName
+          },
+          "init": {
+              "type": "CallExpression",
+              "callee": {
+                  "type": "Identifier",
+                  "name": "require"
+              },
+              "arguments": [
+                  {
+                      "type": "Literal",
+                      "value": dependencyId
+                  }
+              ]
+          }
+      }, {
+          "type": "VariableDeclarator",
+          "id": {
+              "type": "Identifier",
+              "name": paramName
+          },
+          "init": null
+      }],
+      "kind": "var"
+  };
+}
+
+/*
+ * example: var $paramName;
+ */
+function buildParameterDeclaration(paramName) {
+  return {
+        "type": "VariableDeclaration",
+        "declarations": [{
+            "type": "VariableDeclarator",
+            "id": {
+                "type": "Identifier",
+                "name": paramName
+            },
+            "init": null
+        }],
+        "kind": "var"
+    };
+}
+
+/* This block of code will call load on the module with the plugin parameter
+ * and capture the result via callback.
+ * example: $moduleName.load($pluginParameter, function () {
+ *            }, function (r) {
+ *                 $paramName = r;
+ *            });
+ */
+function buildPluginExpression(moduleName, pluginParameter, paramName) {
+  return {
+      "type": "ExpressionStatement",
+      "expression": {
+          "type": "CallExpression",
+          "callee": {
+              "type": "MemberExpression",
+              "computed": false,
+              "object": {
+                  "type": "Identifier",
+                  "name": moduleName
+              },
+              "property": {
+                  "type": "Identifier",
+                  "name": "load"
+              }
+          },
+          "arguments": [
+              {
+                  "type": "Literal",
+                  "value": pluginParameter
+              },
+              {
+                  "type": "FunctionExpression",
+                  "id": null,
+                  "params": [],
+                  "defaults": [],
+                  "body": {
+                      "type": "BlockStatement",
+                      "body": []
+                  },
+                  "rest": null,
+                  "generator": false,
+                  "expression": false
+              },
+              {
+                  "type": "FunctionExpression",
+                  "id": null,
+                  "params": [
+                      {
+                          "type": "Identifier",
+                          "name": "r"
+                      }
+                  ],
+                  "defaults": [],
+                  "body": {
+                      "type": "BlockStatement",
+                      "body": [
+                          {
+                              "type": "ExpressionStatement",
+                              "expression": {
+                                  "type": "AssignmentExpression",
+                                  "operator": "=",
+                                  "left": {
+                                      "type": "Identifier",
+                                      "name": paramName
+                                  },
+                                  "right": {
+                                      "type": "Identifier",
+                                      "name": "r"
+                                  }
+                              }
+                          }
+                      ]
+                  },
+                  "rest": null,
+                  "generator": false,
+                  "expression": false
+              }
+          ]
+      }
   };
 }
 
 
+/*
+ * example: $paramName
+ */
+function buildParameterExpression(paramName) {
+  return {
+      "type": "Identifier",
+      "name": paramName
+  };
+}
+
+function createPluginDependencyExpressionBuilder() {
+  var pluginValueCounter = 0,
+      modules = {};
+
+
+  return function pluginDependencyExpressionBuilder(pluginRequireString) {
+    if(isPlugin(pluginRequireString)) {
+
+      var parts = pluginRequireString.split("!", 2),
+          dependencyId = parts[0],
+          pluginParameter = parts[1],
+          moduleName=  generateVariableNameForModule(dependencyId),
+          paramName = 'pluginValue' + pluginValueCounter++,
+          importModule = !modules[moduleName];
+        modules[moduleName] = true;
+        return {
+          preImportExpressions: [
+            importModule ? buildModuleAndParamaterDeclaration(moduleName, dependencyId, paramName)
+                         : buildParameterDeclaration(paramName),
+            buildPluginExpression(moduleName, pluginParameter, paramName)],
+          importExpression: buildParameterExpression(paramName)
+        };
+    }
+  };
+}
 
 module.exports = createPluginDependencyExpressionBuilder;

--- a/test/amd-module-with-duplicate-plugin.test.js
+++ b/test/amd-module-with-duplicate-plugin.test.js
@@ -3,9 +3,10 @@ var deamdify = require('../')
   , Stream = require('stream');
 
 
-describe('deamdify\'ing AMD module using simplified CommonJS wrapper', function() {
+describe('deamdify\'ing AMD module with duplicate plugin', function() {
 
-  var stream = deamdify('test/data/commonjs-wrapper.js')
+  var stream = deamdify('test/data/amd-module-with-duplicate-plugin.js',
+                        {extensions: ['deamdify-amd-plugins']})
 
   it('should return a stream', function() {
     expect(stream).to.be.an.instanceOf(Stream);
@@ -17,12 +18,12 @@ describe('deamdify\'ing AMD module using simplified CommonJS wrapper', function(
       output += buf;
     });
     stream.on('end', function() {
-      var expected = fs.readFileSync('test/data/commonjs-wrapper.expect.js', 'utf8')
+      var expected = fs.readFileSync('test/data/amd-module-with-duplicate-plugin.expect.js', 'utf8')
       expect(output).to.be.equal(expected);
       done();
     });
 
-    var file = fs.createReadStream('test/data/commonjs-wrapper.js');
+    var file = fs.createReadStream('test/data/amd-module-with-duplicate-plugin.js');
     file.pipe(stream);
   });
 

--- a/test/amd-module-with-plugin-ignored-result.test.js
+++ b/test/amd-module-with-plugin-ignored-result.test.js
@@ -3,9 +3,10 @@ var deamdify = require('../')
   , Stream = require('stream');
 
 
-describe('deamdify\'ing AMD module using simplified CommonJS wrapper', function() {
+describe('deamdify\'ing AMD module with plugin where result is ignored', function() {
 
-  var stream = deamdify('test/data/commonjs-wrapper.js')
+  var stream = deamdify('test/data/amd-module-with-plugin-ignored-result.js',
+                        {extensions: ['deamdify-amd-plugins']})
 
   it('should return a stream', function() {
     expect(stream).to.be.an.instanceOf(Stream);
@@ -17,12 +18,12 @@ describe('deamdify\'ing AMD module using simplified CommonJS wrapper', function(
       output += buf;
     });
     stream.on('end', function() {
-      var expected = fs.readFileSync('test/data/commonjs-wrapper.expect.js', 'utf8')
+      var expected = fs.readFileSync('test/data/amd-module-with-plugin-ignored-result.expect.js', 'utf8')
       expect(output).to.be.equal(expected);
       done();
     });
 
-    var file = fs.createReadStream('test/data/commonjs-wrapper.js');
+    var file = fs.createReadStream('test/data/amd-module-with-plugin-ignored-result.js');
     file.pipe(stream);
   });
 

--- a/test/amd-module-with-plugin.test.js
+++ b/test/amd-module-with-plugin.test.js
@@ -3,9 +3,10 @@ var deamdify = require('../')
   , Stream = require('stream');
 
 
-describe('deamdify\'ing AMD module using simplified CommonJS wrapper', function() {
+describe('deamdify\'ing AMD module with plugin', function() {
 
-  var stream = deamdify('test/data/commonjs-wrapper.js')
+  var stream = deamdify('test/data/amd-module-with-plugin.js',
+                        {extensions: ['deamdify-amd-plugins']})
 
   it('should return a stream', function() {
     expect(stream).to.be.an.instanceOf(Stream);
@@ -17,12 +18,12 @@ describe('deamdify\'ing AMD module using simplified CommonJS wrapper', function(
       output += buf;
     });
     stream.on('end', function() {
-      var expected = fs.readFileSync('test/data/commonjs-wrapper.expect.js', 'utf8')
+      var expected = fs.readFileSync('test/data/amd-module-with-plugin.expect.js', 'utf8')
       expect(output).to.be.equal(expected);
       done();
     });
 
-    var file = fs.createReadStream('test/data/commonjs-wrapper.js');
+    var file = fs.createReadStream('test/data/amd-module-with-plugin.js');
     file.pipe(stream);
   });
 

--- a/test/data/amd-module-with-duplicate-plugin.expect.js
+++ b/test/data/amd-module-with-duplicate-plugin.expect.js
@@ -1,8 +1,9 @@
-var m__my_plug_in = require('./my/plug-in'), pluginValue0, pluginValue1;
+var m__my_plug_in = require('./my/plug-in'), pluginValue0;
 m__my_plug_in.load('paramname1', function () {
 }, function (r) {
     pluginValue0 = r;
 });
+var pluginValue1;
 m__my_plug_in.load('paramname2', function () {
 }, function (r) {
     pluginValue1 = r;

--- a/test/data/amd-module-with-duplicate-plugin.expect.js
+++ b/test/data/amd-module-with-duplicate-plugin.expect.js
@@ -1,0 +1,15 @@
+var m__my_plug_in = require('./my/plug-in'), pluginValue0, pluginValue1;
+m__my_plug_in.load('paramname1', function () {
+}, function (r) {
+    pluginValue0 = r;
+});
+m__my_plug_in.load('paramname2', function () {
+}, function (r) {
+    pluginValue1 = r;
+});
+module.exports = function (cart, paramvalue1, paramvalue2) {
+    function Foo() {
+        return paramvalue1 + paramvalue2;
+    }
+    return Foo;
+}(require('my/cart'), pluginValue0, pluginValue1);

--- a/test/data/amd-module-with-duplicate-plugin.js
+++ b/test/data/amd-module-with-duplicate-plugin.js
@@ -1,0 +1,7 @@
+define("foo/title",
+        ["my/cart", "./my/plug-in!paramname1", "./my/plug-in!paramname2"],
+        function(cart, paramvalue1, paramvalue2) {
+            function Foo() {return paramvalue1 + paramvalue2}
+            return Foo;
+       }
+    );

--- a/test/data/amd-module-with-plugin-ignored-result.expect.js
+++ b/test/data/amd-module-with-plugin-ignored-result.expect.js
@@ -5,7 +5,6 @@ m__my_plug_in.load('paramname', function () {
 });
 module.exports = function (cart) {
     function Foo() {
-        return paramvalue;
     }
     return Foo;
 }(require('my/cart'), pluginValue0);

--- a/test/data/amd-module-with-plugin-ignored-result.expect.js
+++ b/test/data/amd-module-with-plugin-ignored-result.expect.js
@@ -1,0 +1,11 @@
+var m__my_plug_in = require('./my/plug-in'), pluginValue0;
+m__my_plug_in.load('paramname', function () {
+}, function (r) {
+    pluginValue0 = r;
+});
+module.exports = function (cart) {
+    function Foo() {
+        return paramvalue;
+    }
+    return Foo;
+}(require('my/cart'), pluginValue0);

--- a/test/data/amd-module-with-plugin-ignored-result.js
+++ b/test/data/amd-module-with-plugin-ignored-result.js
@@ -1,0 +1,7 @@
+define("foo/title",
+        ["my/cart", "./my/plug-in!paramname"],
+        function(cart) {
+            function Foo() {}
+            return Foo;
+       }
+    );

--- a/test/data/amd-module-with-plugin.expect.js
+++ b/test/data/amd-module-with-plugin.expect.js
@@ -1,0 +1,11 @@
+var m__my_plug_in = require('./my/plug-in'), pluginValue0;
+m__my_plug_in.load('paramname', function () {
+}, function (r) {
+    pluginValue0 = r;
+});
+module.exports = function (cart, paramvalue) {
+    function Foo() {
+        return paramvalue;
+    }
+    return Foo;
+}(require('my/cart'), pluginValue0);

--- a/test/data/amd-module-with-plugin.js
+++ b/test/data/amd-module-with-plugin.js
@@ -1,0 +1,7 @@
+define("foo/title",
+        ["my/cart", "./my/plug-in!paramname"],
+        function(cart, paramvalue) {
+            function Foo() {return paramvalue}
+            return Foo;
+       }
+    );


### PR DESCRIPTION
**DO NOT MERGE THIS**

This PR is meant as a talking point, not complete code.  @tbranyen, you had said that you were also working on a solution to the AMD plugin support; how different is it from mine?  This was my initial solution, but I no longer have confidence in it.  This PR contains step one which is to convert plugins into a call to load on the module.  The default implementation I have is to capture the result of the load function.  This will only work if `module.load()` is synchronous.  The second step was to allow users to override this for specific modules.  However, I have no good solution for when `module.load()` is asynchronous and I believe that to be the norm of `module.load()`.  The expectation of CommonJS is that require is synchronous.  Any suggestions? Has your way been able to get around the async/sync problem?