### PR TITLE
Optionally, support extensions other than just '.js'

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ module.exports = function (file, options) {
       , isUMD = false
       , supportsCommonJs = false;
 
-    if (~options.extensions.indexOf(ext.toLowerCase())) {
+    if (options.extensions.indexOf(ex.toLowerCase()) > -1) {
       try {
         ast = esprima.parse(data)
       } catch (error) {

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ module.exports = function (file, options) {
   var data = '';
   var ext = path.extname(file);
   options = options || {};
+  options.extensions = options.extensions || ['.js'];
 
   var stream = through(write, end);
   return stream;
@@ -42,7 +43,7 @@ module.exports = function (file, options) {
       , isUMD = false
       , supportsCommonJs = false;
 
-    if (ext.toLowerCase() === '.js') {
+    if (~options.extensions.indexOf(ext.toLowerCase())) {
       try {
         ast = esprima.parse(data)
       } catch (error) {


### PR DESCRIPTION
In our use case, we are using `coffeeify` in addition to `deamdify`, but `deamdify` is ignoring the `.coffee` files even though they've already been transpiled by `coffeeify`. This change adds an `extensions` option that can be used to allow `.coffee` files.