### PR TITLE
Preserve code outside of factory function.

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,6 @@ module.exports = function (file, options) {
   function write(buf) { data += buf }
   function end() {
     var ast
-      , tast
       , isAMD = false
       , isUMD = false
       , supportsCommonJs = false;
@@ -81,6 +80,7 @@ module.exports = function (file, options) {
           }
         },
         leave: function(node) {
+          var tnode;
           if (isAMD && (isDefine(node) || isAMDRequire(node))) {
             //define({})
             if (node.arguments.length == 1 &&
@@ -88,7 +88,7 @@ module.exports = function (file, options) {
               // object literal
               var obj = node.arguments[0];
 
-              tast = generateCommonJsModuleForObject(obj);
+              tnode = generateCommonJsModuleForObject(obj);
               this.break();
             } else
             //define(function(){})
@@ -96,7 +96,7 @@ module.exports = function (file, options) {
                 node.arguments[0].type == 'FunctionExpression') {
               var dependenciesIds = extractDependencyIdsFromFactory(node.arguments[0]),
                   factory = node.arguments[0];
-              tast = generateCommonJsModuleForFactory(dependenciesIds, factory);
+              tnode = generateCommonJsModuleForFactory(dependenciesIds, factory);
               this.break();
             } else
             //define(variableName)
@@ -105,7 +105,7 @@ module.exports = function (file, options) {
               // reference
               var obj = node.arguments[0];
 
-              return generateCommonJsModuleForObject(obj).expression;
+              tnode = generateCommonJsModuleForObject(obj);
             } else
             //define([],function(){})
             if (node.arguments.length == 2 &&
@@ -114,7 +114,7 @@ module.exports = function (file, options) {
               var dependenciesIds = extractDependencyIdsFromArrayExpression(node.arguments[0], options.paths)
                 , factory = node.arguments[1];
 
-              tast = generateCommonJsModuleForFactory(dependenciesIds, factory);
+              tnode = generateCommonJsModuleForFactory(dependenciesIds, factory);
               this.break();
             } else
             //define("a b c".split(' '), function(){})
@@ -126,7 +126,7 @@ module.exports = function (file, options) {
                   , dependenciesIds = extractDependencyIdsFromCallExpression(dependenciesCode, options.paths)
                   , factory = node.arguments[1];
 
-                tast = generateCommonJsModuleForFactory(dependenciesIds, factory);
+                tnode = generateCommonJsModuleForFactory(dependenciesIds, factory);
                 this.break();
               } catch(e) {
                 console.log("failed to evaluate dependencies:", dependenciesCode, e)
@@ -139,7 +139,7 @@ module.exports = function (file, options) {
               var dependenciesIds = extractDependencyIdsFromFactory(node.arguments[1])
                 , factory = node.arguments[1];
 
-              tast = generateCommonJsModuleForFactory(dependenciesIds, factory);
+              tnode = generateCommonJsModuleForFactory(dependenciesIds, factory);
               this.break();
             } else
             //define('modulename', [], function(){})
@@ -150,7 +150,7 @@ module.exports = function (file, options) {
               var dependenciesIds = extractDependencyIdsFromArrayExpression(node.arguments[1], options.paths)
                 , factory = node.arguments[2];
 
-              tast = generateCommonJsModuleForFactory(dependenciesIds, factory);
+              tnode = generateCommonJsModuleForFactory(dependenciesIds, factory);
               this.break();
             } else
             //define('modulename', "a b c".split(' '), function(){})
@@ -163,13 +163,14 @@ module.exports = function (file, options) {
                   , dependenciesIds = extractDependencyIdsFromCallExpression(dependenciesCode, options.paths)
                   , factory = node.arguments[2];
 
-                tast = generateCommonJsModuleForFactory(dependenciesIds, factory);
+                tnode = generateCommonJsModuleForFactory(dependenciesIds, factory);
                 this.break();
               } catch(e) {
                 console.log("failed to evaluate dependencies:", dependenciesCode, e)
               }
             }
           }
+          return tnode;
         }
       });
     }
@@ -180,29 +181,25 @@ module.exports = function (file, options) {
       return;
     }
 
-    tast = tast || ast;
-
     //console.log('-- TRANSFORMED AST --');
-    //console.log(util.inspect(tast, false, null));
+    //console.log(util.inspect(ast, false, null));
     //console.log('---------------------');
 
-    var out = escodegen.generate(tast);
+    var out = escodegen.generate(ast);
     stream.queue(out);
     stream.queue(null);
   }
 };
 
 function generateCommonJsModuleForObject(obj) {
-  return { type: 'ExpressionStatement',
-    expression:
-     { type: 'AssignmentExpression',
-       operator: '=',
-       left:
-        { type: 'MemberExpression',
-          computed: false,
-          object: { type: 'Identifier', name: 'module' },
-          property: { type: 'Identifier', name: 'exports' } },
-       right: obj } };
+  return { type: 'AssignmentExpression',
+    operator: '=',
+    left:
+    { type: 'MemberExpression',
+      computed: false,
+      object: { type: 'Identifier', name: 'module' },
+      property: { type: 'Identifier', name: 'exports' } },
+    right: obj };
 }
 
 function extractDependencyIdsFromArrayExpression(dependencies, paths) {
@@ -252,7 +249,17 @@ function generateCommonJsModuleForFactory(dependenciesIds, factory) {
   var program,
       exportResult = support.doesFactoryHaveReturn(factory);
   if(dependenciesIds.length === 0 && !exportResult) {
-    program = factory.body.body;
+    return {
+      "type": "CallExpression",
+      "callee": {
+        "type": "FunctionExpression",
+        "id": null,
+        "params": [],
+        "defaults": [],
+        "body": factory.body
+      },
+      "arguments": []
+    };
   } else {
 
     var importExpressions = [];
@@ -276,38 +283,28 @@ function generateCommonJsModuleForFactory(dependenciesIds, factory) {
     if(exportResult) {
       //wrap with assignment
       body = {
-        "type": "ExpressionStatement",
-            "expression":{
-            "type": "AssignmentExpression",
-            "operator": "=",
-            "left": {
-                "type": "MemberExpression",
-                "computed": false,
-                "object": {
-                    "type": "Identifier",
-                    "name": "module"
-                },
-                "property": {
-                    "type": "Identifier",
-                    "name": "exports"
-                }
-            },
-            "right": callFactoryWithImports
+        "type": "AssignmentExpression",
+        "operator": "=",
+        "left": {
+          "type": "MemberExpression",
+          "computed": false,
+          "object": {
+            "type": "Identifier",
+            "name": "module"
+          },
+          "property": {
+            "type": "Identifier",
+            "name": "exports"
           }
+        },
+        "right": callFactoryWithImports
       };
     } else {
-      body = {
-              "type": "ExpressionStatement",
-              "expression": callFactoryWithImports
-          };
+      body = callFactoryWithImports;
     }
 
-
-    //program
-    program = [body];
+    return body;
   }
-  return { type: 'Program',
-           body: program };
 }
 
 //NOTE: this is the order as specified in RequireJS docs; don't changes

--- a/index.js
+++ b/index.js
@@ -251,14 +251,12 @@ function generateCommonJsModuleForFactory(dependenciesIds, factory) {
   if(dependenciesIds.length === 0 && !exportResult) {
     return {
       "type": "CallExpression",
-      "callee": {
-        "type": "FunctionExpression",
-        "id": null,
-        "params": [],
-        "defaults": [],
-        "body": factory.body
-      },
-      "arguments": []
+      "callee": factory,
+      "arguments": [
+        { "type": "Identifier", "name": "require" },
+        { "type": "Identifier", "name": "exports" },
+        { "type": "Identifier", "name": "module" }
+      ]
     };
   } else {
 

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ module.exports = function (file, options) {
             //define([],function(){})
             if (node.arguments.length == 2 &&
                 node.arguments[0].type == 'ArrayExpression' &&
-                node.arguments[1].type == 'FunctionExpression') {
+                (node.arguments[1].type == 'FunctionExpression' || node.arguments[1].type == 'Identifier')) {
               var dependenciesIds = extractDependencyIdsFromArrayExpression(node.arguments[0], options.paths)
                 , factory = node.arguments[1];
 
@@ -120,7 +120,7 @@ module.exports = function (file, options) {
             //define("a b c".split(' '), function(){})
             if (node.arguments.length == 2 &&
                 node.arguments[0].type == 'CallExpression' &&
-                node.arguments[1].type == 'FunctionExpression') {
+                (node.arguments[1].type == 'FunctionExpression' || node.arguments[1].type == 'Identifier')) {
               try {
                 var dependenciesCode = node.arguments[0]
                   , dependenciesIds = extractDependencyIdsFromCallExpression(dependenciesCode, options.paths)
@@ -135,7 +135,7 @@ module.exports = function (file, options) {
             //define('modulename',function(){})
             if (node.arguments.length == 2 &&
                 node.arguments[0].type == 'Literal' &&
-                node.arguments[1].type == 'FunctionExpression') {
+                (node.arguments[1].type == 'FunctionExpression' || node.arguments[1].type == 'Identifier')) {
               var dependenciesIds = extractDependencyIdsFromFactory(node.arguments[1])
                 , factory = node.arguments[1];
 
@@ -146,7 +146,7 @@ module.exports = function (file, options) {
             if (node.arguments.length == 3 &&
                 node.arguments[0].type == 'Literal' &&
                 node.arguments[1].type == 'ArrayExpression' &&
-                node.arguments[2].type == 'FunctionExpression') {
+                (node.arguments[2].type == 'FunctionExpression' || node.arguments[2].type == 'Identifier')) {
               var dependenciesIds = extractDependencyIdsFromArrayExpression(node.arguments[1], options.paths)
                 , factory = node.arguments[2];
 
@@ -157,7 +157,7 @@ module.exports = function (file, options) {
             if (node.arguments.length == 3 &&
                 node.arguments[0].type == 'Literal' &&
                 node.arguments[1].type == 'CallExpression' &&
-                node.arguments[2].type == 'FunctionExpression') {
+                (node.arguments[2].type == 'FunctionExpression' || node.arguments[2].type == 'Identifier')) {
               try {
                 var dependenciesCode = node.arguments[1]
                   , dependenciesIds = extractDependencyIdsFromCallExpression(dependenciesCode, options.paths)
@@ -247,7 +247,7 @@ function isCommonJsWrappingParameters(parameters) {
 
 function generateCommonJsModuleForFactory(dependenciesIds, factory) {
   var program,
-      exportResult = support.doesFactoryHaveReturn(factory);
+      exportResult = factory.type !== 'FunctionExpression' || support.doesFactoryHaveReturn(factory);
   if(dependenciesIds.length === 0 && !exportResult) {
     return {
       "type": "CallExpression",

--- a/test/data/commonjs-wrapper.expect.js
+++ b/test/data/commonjs-wrapper.expect.js
@@ -1,5 +1,5 @@
-(function () {
+(function (require, exports, module) {
     var a = require('a'), b = require('b');
     exports.action = function () {
     };
-}());
+}(require, exports, module));

--- a/test/data/commonjs-wrapper.expect.js
+++ b/test/data/commonjs-wrapper.expect.js
@@ -1,3 +1,5 @@
-var a = require('a'), b = require('b');
-exports.action = function () {
-};
+(function () {
+    var a = require('a'), b = require('b');
+    exports.action = function () {
+    };
+}());

--- a/test/data/define-module-name-factory.expect.js
+++ b/test/data/define-module-name-factory.expect.js
@@ -1,4 +1,4 @@
-(function () {
+(function (require, exports) {
     var foo = require('foo');
     exports.bar = {};
-}());
+}(require, exports));

--- a/test/data/define-module-name-factory.expect.js
+++ b/test/data/define-module-name-factory.expect.js
@@ -1,2 +1,4 @@
-var foo = require('foo');
-exports.bar = {};
+(function () {
+    var foo = require('foo');
+    exports.bar = {};
+}());

--- a/test/data/define-module-name-factory.js
+++ b/test/data/define-module-name-factory.js
@@ -1,4 +1,4 @@
-define('amd-module', function (require, exports, module) {
+define('amd-module', function (require, exports) {
   var foo = require('foo');
   exports.bar = {};
 });

--- a/test/data/identifier-as-factory.expect.js
+++ b/test/data/identifier-as-factory.expect.js
@@ -1,0 +1,7 @@
+(function (factory) {
+    if (true) {
+        module.exports = factory(require('jquery'), require('./version'));
+    }
+}(function ($) {
+    return $.widget;
+}));

--- a/test/data/identifier-as-factory.js
+++ b/test/data/identifier-as-factory.js
@@ -1,0 +1,11 @@
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+		define( [ "jquery", "./version" ], factory );
+	} else {
+		factory( jQuery );
+	}
+}( function( $ ) {
+
+return $.widget;
+
+} ) );

--- a/test/data/umd-webamd-with-function.expect.js
+++ b/test/data/umd-webamd-with-function.expect.js
@@ -1,0 +1,10 @@
+var foo;
+factory();
+if (true) {
+    module.exports = function () {
+        return foo;
+    }();
+}
+function factory() {
+    foo = {};
+}

--- a/test/data/umd-webamd-with-function.expect.js
+++ b/test/data/umd-webamd-with-function.expect.js
@@ -1,10 +1,11 @@
 var foo;
-factory();
 if (true) {
     module.exports = function () {
+        var foo = 'good';
+        evil();
         return foo;
     }();
 }
-function factory() {
-    foo = {};
+function evil() {
+    foo = 'evil';
 }

--- a/test/data/umd-webamd-with-function.js
+++ b/test/data/umd-webamd-with-function.js
@@ -1,0 +1,10 @@
+var foo;
+factory();
+if (typeof define === 'function' && define.amd) {
+    define(function () { return foo; });
+} else {
+    root.myModule = foo;
+}
+function factory() {
+    foo = {};
+}

--- a/test/data/umd-webamd-with-function.js
+++ b/test/data/umd-webamd-with-function.js
@@ -1,10 +1,13 @@
 var foo;
-factory();
 if (typeof define === 'function' && define.amd) {
-    define(function () { return foo; });
+    define(function () {
+        var foo = 'good';
+        evil();
+        return foo;
+    });
 } else {
     root.myModule = foo;
 }
-function factory() {
-    foo = {};
+function evil() {
+    foo = 'evil';
 }

--- a/test/data/umd-webamd.expect.js
+++ b/test/data/umd-webamd.expect.js
@@ -1,6 +1,8 @@
-var foo = function bar() {}
-function factory() {}
+var foo = function bar() {
+};
 if (true) {
     foo();
     module.exports = factory;
+}
+function factory() {
 }

--- a/test/data/umd-webamd.expect.js
+++ b/test/data/umd-webamd.expect.js
@@ -1,3 +1,5 @@
+var foo = function bar() {}
+function factory() {}
 if (true) {
     foo();
     module.exports = factory;

--- a/test/data/umd-webamd.js
+++ b/test/data/umd-webamd.js
@@ -1,8 +1,10 @@
-var foo = function bar() {}
-function factory() {}
+var foo = function bar() {
+};
 if (typeof define === 'function' && define.amd) {
     foo();
     define(factory);
 } else {
     root.myModule = factory();
+}
+function factory() {
 }

--- a/test/data/umd-webamd.js
+++ b/test/data/umd-webamd.js
@@ -1,3 +1,5 @@
+var foo = function bar() {}
+function factory() {}
 if (typeof define === 'function' && define.amd) {
     foo();
     define(factory);

--- a/test/identifier-as-factory.test.js
+++ b/test/identifier-as-factory.test.js
@@ -1,0 +1,29 @@
+var deamdify = require('../')
+  , fs = require('fs')
+  , Stream = require('stream');
+
+
+describe('deamdify\'ing module using a identifier as factory', function() {
+
+  var stream = deamdify('test/data/identifier-as-factory.js')
+
+  it('should return a stream', function() {
+    expect(stream).to.be.an.instanceOf(Stream);
+  });
+
+  it('should assume factory is a function that returns exports', function(done) {
+    var output = '';
+    stream.on('data', function(buf) {
+      output += buf;
+    });
+    stream.on('end', function() {
+      var expected = fs.readFileSync('test/data/identifier-as-factory.expect.js', 'utf8')
+      expect(output).to.be.equal(expected.trim());
+      done();
+    });
+
+    var file = fs.createReadStream('test/data/identifier-as-factory.js');
+    file.pipe(stream);
+  });
+
+});

--- a/test/umd-webamd-with-function.test.js
+++ b/test/umd-webamd-with-function.test.js
@@ -1,0 +1,29 @@
+var deamdify = require('../')
+  , fs = require('fs')
+  , Stream = require('stream');
+
+
+describe('deamdify\'ing a UMD module using a definition function without CommonJS support', function() {
+
+  var stream = deamdify('test/data/umd-webamd-with-function.js')
+
+  it('should return a stream', function() {
+    expect(stream).to.be.an.instanceOf(Stream);
+  });
+
+  it('should transform define and preserve closure', function(done) {
+    var output = '';
+    stream.on('data', function(buf) {
+      output += buf;
+    });
+    stream.on('end', function() {
+      var expected = fs.readFileSync('test/data/umd-webamd-with-function.expect.js', 'utf8')
+      expect(output).to.be.equal(expected.trim());
+      done();
+    });
+
+    var file = fs.createReadStream('test/data/umd-webamd-with-function.js');
+    file.pipe(stream);
+  });
+
+});


### PR DESCRIPTION
As mentioned in #33, popular libs often do their main work outside of
the factory. Thus the factory is reduced to return a variable that is
declared and defined in the enclosing closure. UMD boilerplate is
usually an afterthought so to preserve the code outside of the factory
is very important!
