### PR TITLE
Setup auto-publishing onto npm on tag release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,14 @@ language: "node_js"
 node_js:
   - "0.10"
   - "0.12"
+  - v4
+  - v6
+  - node
+  
+deploy:
+  provider: npm
+  email: <...>
+  api_key: <...>
+  on:
+    tags: true
+    node: v6


### PR DESCRIPTION
Ideally you want to configure it with you credentials and secure them with travis encrypt. 
And even easier:

``` bash
# get the _authToken:
cat ~/.npmrc

# then paste it as prompted in
travis setup npm
```

Cf. https://docs.travis-ci.com/user/deployment/npm
